### PR TITLE
Fix/hash make error and refining in the hashing.php

### DIFF
--- a/publish/hashing.php
+++ b/publish/hashing.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
  * @contact  eric@zhu.email
  * @license  https://github.com/hyperf-ext/hashing/blob/master/LICENSE
  */
+
+use function Hyperf\Support\env;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -37,7 +40,7 @@ return [
         'bcrypt' => [
             'class' => \HyperfExt\Hashing\Driver\BcryptDriver::class,
             'options' => [
-                'rounds' => env('BCRYPT_ROUNDS', 10),
+                'rounds' => (int) env('BCRYPT_ROUNDS', 10),
             ],
         ],
 

--- a/src/HashManager.php
+++ b/src/HashManager.php
@@ -15,6 +15,7 @@ use HyperfExt\Hashing\Contract\DriverInterface;
 use HyperfExt\Hashing\Contract\HashInterface;
 use HyperfExt\Hashing\Driver\BcryptDriver;
 use InvalidArgumentException;
+use function Hyperf\Support\make;
 
 class HashManager implements HashInterface
 {


### PR DESCRIPTION
## Fix HashManager make() error

**Error encountered:**
`Call to undefined function HyperfExt\Hashing\make()[92]`

**File affected:**
`vendor/hyperf-ext/hashing/src/HashManager.php`

**Cause:**
The helper `make()` was not imported:
`use function Hyperf\Support\make;`

**Solution:**
Added the proper import so HashManager can call `make()` without errors.

---

## Minor refinement in hashing.php

**Changes:**
- Added import for `env` helper:
  ```php
  use function Hyperf\Support\env;
  ```
- Added type int type:
`rounds' => (int) env('BCRYPT_ROUNDS', 12)`
  
  
